### PR TITLE
Build: support pkg-config

### DIFF
--- a/qssh.pri
+++ b/qssh.pri
@@ -139,6 +139,9 @@ macx {
     !isEqual(IDE_SOURCE_TREE, $$IDE_BUILD_TREE):copydata = 1
 }
 
+CONFIG += link_pkgconfig
+PKGCONFIG += botan-2
+
 INCLUDEPATH += \
     $$IDE_BUILD_TREE/src \ # for <app/app_version.h>
     $$IDE_SOURCE_TREE/src/libs


### PR DESCRIPTION
The Botan library ships a pkg-config file, which helps finding where the
library has been installed.

This commit does not remove the previously hardcoded paths, in order to
keep compatibility for existing users of the library.