### PR TITLE
Improve CMake buildsystem; fix typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,19 +3,42 @@ cmake_minimum_required(VERSION 3.14)
 # set the project name and version
 project(QSsh VERSION 1.0 LANGUAGES CXX)
 
+# use GNU installation dirs
+include(GNUInstallDirs)
+
+# cached variables
+set(QSSH_BUILD_EXAMPLES True CACHE BOOL "Build the QSsh examples.")
+set(BUILD_SHARED_LIBS False CACHE BOOL "Build QSsh using shared libraries.")
+set(BOTAN_INCLUDE_DIR "" CACHE PATH "Path of the Botan include directory. Set this if user specified BOTAN_LIBRARY location is used.")
+set(BOTAN_LIBRARY "" CACHE FILEPATH "Path of the Botan library. Leave blank if you want to use the automated package search.")
+
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-if(MSVC)
+# user specified Botan library?
+# note in this case user must take care of installation of library/header files if required
+if(NOT "${BOTAN_LIBRARY}" STREQUAL "")
+  add_library(Botan2 UNKNOWN IMPORTED)
+  if(WIN32)
+    set_property(TARGET Botan2 PROPERTY IMPORTED_IMPLIB "${BOTAN_LIBRARY}")
+  else()
+    set_property(TARGET Botan2 PROPERTY IMPORTED_LOCATION "${BOTAN_LIBRARY}")
+  endif()
+  target_include_directories(Botan2 INTERFACE "${BOTAN_INCLUDE_DIR}")
+  set_property(GLOBAL PROPERTY BOTAN_LIB Botan2)
+else()
+  # use package search to find the Botan module
+  if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4005")
     set(BOTAN_LIB ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/botan.lib)
-else(MSVC)
+  else()
     find_package(PkgConfig REQUIRED)
     pkg_search_module(Botan REQUIRED IMPORTED_TARGET GLOBAL botan-2)
-
     set_property(GLOBAL PROPERTY BOTAN_LIB PkgConfig::Botan)
-endif(MSVC)
+  endif()
+endif()
+
 
 find_package(QT NAMES Qt5 Qt6 COMPONENTS Core Quick REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Widgets Network REQUIRED)
@@ -31,17 +54,21 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
+# the main library
 add_subdirectory(src)
-add_subdirectory(examples)
+
+# the examples
+if(QSSH_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 # INSTALL RULES
-install(EXPORT QSsh-targets DESTINATION lib)
+#install(EXPORT QSsh-targets DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(EXPORT QSsh-targets
   FILE QSshTargets.cmake
   NAMESPACE QSsh::
-  DESTINATION share/QSsh/cmake
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/QSsh/cmake
 )
 
-
 install(FILES "${CMAKE_SOURCE_DIR}/cmakeFindModules/QSshConfig.cmake"
-        DESTINATION share/QSsh/cmake)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/QSsh/cmake)

--- a/examples/ssh-shell/CMakeLists.txt
+++ b/examples/ssh-shell/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(ssh-hell
+add_executable(ssh-shell
     argumentscollector.cpp  main.cpp  shell.cpp)
 
 target_link_libraries(ssh-shell PRIVATE QSsh Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network ${BOTAN_LIB})

--- a/src/libs/qssh/CMakeLists.txt
+++ b/src/libs/qssh/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_library(QSsh
+set(LIBTYPE STATIC)
+if(BUILD_SHARED_LIBS)
+  set(LIBTYPE SHARED)
+endif()
+
+add_library(QSsh ${LIBTYPE}
     sshsendfacility.cpp
     sshremoteprocess.cpp
     sshpacketparser.cpp
@@ -35,7 +40,7 @@ add_library(QSsh
     qssh.qrc)
 
 get_property(BOTAN_LIB GLOBAL PROPERTY BOTAN_LIB)
-target_link_libraries( QSsh Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Widgets ${BOTAN_LIB})
+target_link_libraries(QSsh Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network Qt${QT_VERSION_MAJOR}::Widgets ${BOTAN_LIB})
 
 # state that anybody linking to us needs to include the current source dir
 target_include_directories(QSsh
@@ -49,8 +54,8 @@ target_include_directories(QSsh
 #INSTALL RULES
 install(
   DIRECTORY .
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   COMPONENT headers
   FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
 )
-install(TARGETS QSsh DESTINATION lib EXPORT QSsh-targets)
+install(TARGETS QSsh DESTINATION ${CMAKE_INSTALL_LIBDIR} EXPORT QSsh-targets)


### PR DESCRIPTION
* Fix a typo in one of the CMakeLists.txt files
* Enable building of shared library
* Allow to set a custom BOTAN library location
* Build examples only when QSSH_BUILD_EXAMPLES is set
* Use GNUInstallDirs include and variables