### PR TITLE
SFTP upload directory make append dir path optional

### DIFF
--- a/src/libs/qssh/sftpchannel.cpp
+++ b/src/libs/qssh/sftpchannel.cpp
@@ -239,7 +239,7 @@ SftpJobId SftpChannel::downloadFile(const QString &remoteFilePath, QSharedPointe
 }
 
 SftpJobId SftpChannel::uploadDir(const QString &localDirPath,
-    const QString &remoteParentDirPath)
+    const QString &remoteParentDirPath, bool appendDirPath)
 {
     if (state() != Initialized)
         return SftpInvalidJob;
@@ -248,8 +248,10 @@ SftpJobId SftpChannel::uploadDir(const QString &localDirPath,
         return SftpInvalidJob;
     const Internal::SftpUploadDir::Ptr uploadDirOp(
         new Internal::SftpUploadDir(++d->m_nextJobId));
-    const QString remoteDirPath
-        = remoteParentDirPath + u'/' + localDir.dirName();
+    QString remoteDirPath = remoteParentDirPath;
+    if (appendDirPath) {
+        remoteDirPath += u'/' + localDir.dirName();
+    }
     const Internal::SftpMakeDir::Ptr mkdirOp(
         new Internal::SftpMakeDir(++d->m_nextJobId, remoteDirPath, uploadDirOp));
     uploadDirOp->mkdirsInProgress.insert(mkdirOp,

--- a/src/libs/qssh/sftpchannel.h
+++ b/src/libs/qssh/sftpchannel.h
@@ -202,11 +202,11 @@ public:
     /*!
      * \brief Uploads a local directory (recursively) with files to the remote host
      * \param localDirPath The path to an existing local directory
-     * \param remoteParentDirPath The remote path to upload it to, the name of the local directory will be appended to this
+     * \param remoteParentDirPath The remote path to upload it to, the name of the local directory will be appended to this if appendDirPath is set
      * \return A unique ID identifying this job
      */
     SftpJobId uploadDir(const QString &localDirPath,
-        const QString &remoteParentDirPath);
+        const QString &remoteParentDirPath, bool appendDirPath = true);
 
     /*!
      * \brief Downloads a remote directory (recursively) to a local path


### PR DESCRIPTION
When uploading a directory via SFTP make appending the directory name optional.

Previously, when uploading

xxx/myDir/*

the directory name **myDir** would be automatically appended to the **destination**:

yyy/destination/myDir/*

This change allows now to upload the contents of **myDir** directly to **destination**:

yyy/destination/*