### PR TITLE
Use rand() instead of QRandomGenerator for performance reasons

### DIFF
--- a/examples/sftp/sftptest.cpp
+++ b/examples/sftp/sftptest.cpp
@@ -30,6 +30,7 @@
 
 #include "sftptest.h"
 
+#include <cstdlib>
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
@@ -151,11 +152,7 @@ void SftpTest::handleChannelInitialized()
         if (success) {
             int content[1024/sizeof(int)];
             for (size_t j = 0; j < sizeof content / sizeof content[0]; ++j)
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-                content[j] = QRandomGenerator::system()->generate();
-#else
-                content[j] = qrand();
-#endif
+                content[j] = rand();
             file->write(reinterpret_cast<char *>(content), sizeof content);
             file->close();
         }
@@ -302,11 +299,7 @@ void SftpTest::handleSftpJobFinished(SftpJobId job, const SftpError errorType, c
             for (quint64 block = 0; block < blockCount; ++block) {
                 int content[blockSize/sizeof(int)];
                 for (size_t j = 0; j < sizeof content / sizeof content[0]; ++j) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-                    content[j] = QRandomGenerator::system()->generate();
-#else
-                    content[j] = qrand();
-#endif
+                    content[j] = rand();
                 }
                 m_localBigFile->write(reinterpret_cast<char *>(content),
                     sizeof content);


### PR DESCRIPTION
When running tests I found that QRandomGenerator took ages (literally minutes) to generate random numbers for the test binary data. Using **rand()** instead decreases this time to non-noticable. Since no high-quality random numbers are required for the testing purposes the choice of **rand()** should be justified.